### PR TITLE
Index 장르별 item 리스트 조회 + 각 카테고리 번호별로 총 30개 item 리스트 랜덤 조회 기능

### DIFF
--- a/back-end/src/main/java/com/webservice/bookstore/domain/entity/item/ItemRepository.java
+++ b/back-end/src/main/java/com/webservice/bookstore/domain/entity/item/ItemRepository.java
@@ -15,8 +15,8 @@ public interface ItemRepository extends JpaRepository<Item,Long> {
    @Query(value = "select * from Item order by rand() limit :cnt",nativeQuery = true)
    List<Item> getThisMonthbooks(@Param("cnt") int cnt);
 
-   @Query(value = "select * from Item where category_id = :category_id order by rand() limit 3",nativeQuery = true)
-   List<Item> getRandomListByGenre(@Param("category_id") Long category_id);
+    @Query(value = "select * from (select I.*, row_number() over(partition by category_id order by rand()) rn from item I) I where rn <= 3", nativeQuery = true)
+   List<Item> getRandomListByGenre();
 
    @EntityGraph(value = "Item.category")
    List<Item> findAllByCategoryId(Long id);

--- a/back-end/src/main/java/com/webservice/bookstore/service/ItemServiceImpl.java
+++ b/back-end/src/main/java/com/webservice/bookstore/service/ItemServiceImpl.java
@@ -10,8 +10,6 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
-
 @Service
 @Log4j2
 @RequiredArgsConstructor
@@ -23,22 +21,22 @@ public class ItemServiceImpl implements ItemServices{
         List<Item> list=itemRepository.getThisMonthbooks(cnt);
         List<ItemDto> res = new ArrayList<>();
         for(int i=0;i<list.size();i++){
-            res.add(entityToDto(list.get(i)));
+            res.add(ItemDto.of(list.get(i)));
         }
         return res;
     }
 
     @Override
-    public List<ItemDto> getRandomListByGenre(ItemDto itemDto) {
+    public List<ItemDto> getRandomListByGenre() {
 
-        List<Item> itemListByGenre = itemRepository.getRandomListByGenre(itemDto.getCategory_id());
+        List<Item> itemList = itemRepository.getRandomListByGenre();
 
-        List<ItemDto> res = new ArrayList<>();
-        for (Item item : itemListByGenre) {
-            res.add(entityToDto(item));
+        List<ItemDto> itemDtoList = new ArrayList<>();
+        for (Item item : itemList) {
+            itemDtoList.add(ItemDto.of(item));
         }
 
-        return res;
+        return itemDtoList;
     }
 
     @Override
@@ -48,7 +46,7 @@ public class ItemServiceImpl implements ItemServices{
 
         List<ItemDto> itemDtoList = new ArrayList<>();
         for(Item item : itemList) {
-            ItemDto dto = entityToDto(item);
+            ItemDto dto = ItemDto.of(item);
             itemDtoList.add(dto);
         }
 

--- a/back-end/src/main/java/com/webservice/bookstore/service/ItemServices.java
+++ b/back-end/src/main/java/com/webservice/bookstore/service/ItemServices.java
@@ -7,40 +7,10 @@ import com.webservice.bookstore.web.dto.ItemDto;
 import java.util.List;
 
 public interface ItemServices {
-    default ItemDto entityToDto(Item item) {
-        ItemDto dto = ItemDto.builder()
-                .id(item.getId())
-                .category_id(item.getCategory().getId())
-                .description(item.getDescription())
-                .imageUrl(item.getImageUrl())
-                .author(item.getAuthor())
-                .publisher(item.getPublisher())
-                .quantity(item.getQuantity())
-                .price(item.getPrice())
-                .isbn(item.getIsbn())
-                .name(item.getName())
-                .build();
-        return dto;
-    }
-
-    default Item dtoToEntity(ItemDto dto) {
-        Item item = Item.builder().category(Category.builder().id(dto.getCategory_id()).build())
-                .isbn(dto.getIsbn())
-                .description(dto.getDescription())
-                .author(dto.getAuthor())
-                .publisher(dto.getPublisher())
-                .price(dto.getPrice())
-                .name(dto.getName())
-                .quantity(dto.getQuantity())
-                .id(dto.getId())
-                .imageUrl(dto.getImageUrl())
-                .build();
-        return item;
-    }
 
     List<ItemDto> getRandomList(int cnt);
 
-    List<ItemDto> getRandomListByGenre(ItemDto itemDto);
+    List<ItemDto> getRandomListByGenre();
 
     List<ItemDto> getListByGenre(Long category_id);
 }

--- a/back-end/src/main/java/com/webservice/bookstore/web/controller/IndexController.java
+++ b/back-end/src/main/java/com/webservice/bookstore/web/controller/IndexController.java
@@ -1,18 +1,21 @@
 package com.webservice.bookstore.web.controller;
 
 import com.webservice.bookstore.domain.entity.item.ItemLinkResource;
-import com.webservice.bookstore.service.ItemService;
 import com.webservice.bookstore.service.ItemServices;
 import com.webservice.bookstore.web.dto.ItemDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.RepresentationModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
@@ -53,14 +56,27 @@ public class IndexController {
     }
 
     /*
-    hover 시 각 장르별 item 정보 3개 랜덤 조회 요청
+    hover 시 각 장르별 item 정보 3개씩 랜덤 조회 요청
     */
     @GetMapping(value = "/genre/")
-    public ResponseEntity<List<ItemDto>> getRandomListByGenre(@RequestBody ItemDto itemDto) {
+    public ResponseEntity getRandomListByGenre() {
 
-        List<ItemDto> itemDtoList = itemService.getRandomListByGenre(itemDto);
+        List<ItemDto> itemDtoList = itemService.getRandomListByGenre();
 
-        return new ResponseEntity<>(itemDtoList, HttpStatus.OK);
+        List<ItemLinkResource> emList = itemDtoList.stream()
+                .map(itemDto -> new ItemLinkResource(itemDto,
+                        linkTo(methodOn(IndexController.class).getListByGenre(itemDto.getId())).withSelfRel()))
+                .collect(Collectors.toList());
+
+        // 카테고리 번호별로 분류한 json 구조로 직렬화(selialize)
+        Map<String, List<ItemLinkResource>> first = new HashMap<>();
+        for(int i = 0; i < itemDtoList.size(); i+=3) {
+            first.put(String.valueOf(i/3), new ArrayList<>(emList.subList(i, Math.min(i+3, emList.size()))));
+        }
+
+        RepresentationModel<?> model = CollectionModel.of(first);
+
+        return new ResponseEntity<>(model, HttpStatus.OK);
     }
 
     /*


### PR DESCRIPTION
Index :
1. 장르별 아이템 리스트 조회 결과 값에 HATEOAS 적용
2. hover 시 각 장르별(=카테고리) 3개의 item 리스트가 아닌, 각 카테고리 번호별로 총 30개의 item 리스트 랜덤 조회 기능으로 수정(SQL쿼리 수정, HATEOAS 적용)
Item :
1. Entity/Dto 변환 메소드 정의를 ItemService 인터페이스에서 제거하고, ItemDto에 정의 및 그와 관련된 로직 수정